### PR TITLE
BR-20 Add jacoco for code coverage and verify %

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,59 @@
                     </dependency>
                 </dependencies>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.8</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule>
+                                    <element>CLASS</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>99%</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>99%</minimum>
+                                        </limit>
+                                    </limits>
+                                    <excludes>
+                                        <exclude>com.bobocode.svydovets.annotation.**</exclude>
+<!--                                        <exclude>com.bobocode.svydovets.annotation.bean.factory.DefaultBeanFactoryImpl</exclude>-->
+                                    </excludes>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+                <configuration>
+                    <excludes>
+<!--                        <exclude>com/bobocode/svydovets/**/*.class</exclude>-->
+                    </excludes>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -153,17 +153,18 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>99%</minimum>
+                                            <minimum>80%</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>99%</minimum>
+                                            <minimum>80%</minimum>
                                         </limit>
                                     </limits>
                                     <excludes>
-                                        <exclude>com.bobocode.svydovets.annotation.**</exclude>
-<!--                                        <exclude>com.bobocode.svydovets.annotation.bean.factory.DefaultBeanFactoryImpl</exclude>-->
+                                        <exclude>com.bobocode.svydovets.annotation.exception.**</exclude>
+                                        <exclude>com.bobocode.svydovets.annotation.bean.factory.**</exclude>
+                                        <exclude>com.bobocode.svydovets.annotation.register.**</exclude>
                                     </excludes>
                                 </rule>
                             </rules>


### PR DESCRIPTION
- start code coverage with `maven -verify`
- fail build if code coverage is less than 80%

if build failed - see what is not covered:

![image](https://user-images.githubusercontent.com/33624178/214264032-485c9586-d4b6-4c64-a820-23c793458251.png)

1. <img src="https://user-images.githubusercontent.com/33624178/214263566-d679fdcd-7346-4fa6-8dfd-0de3c25d217e.png" width=50% height=50%>
2. <img src="https://user-images.githubusercontent.com/33624178/214264128-8bb6c4d9-4b56-4a49-8562-1990fe0b360a.png" width=50% height=50%>
3. <img src="https://user-images.githubusercontent.com/33624178/214264192-4ab56dbd-cae4-4113-bac1-80d22166cad9.png" width=50% height=50%>

[jacoco docs ](https://www.jacoco.org/jacoco/trunk/doc/check-mojo.html)
[Maven Usage Example](https://www.jacoco.org/jacoco/trunk/doc/examples/build/pom.xml)